### PR TITLE
Since Python 3, the last argument to __import__() cannot be negative.…

### DIFF
--- a/pymel/core/uitypes.py
+++ b/pymel/core/uitypes.py
@@ -3907,7 +3907,7 @@ class AELoader(type):
 
     @staticmethod
     def load(modname, classname, nodename):
-        mod = __import__(modname, globals(), locals(), [classname], -1)
+        mod = __import__(modname, globals(), locals(), [classname])
         try:
             cls = getattr(mod, classname)
             cls(nodename)


### PR DESCRIPTION
… We could have gone for 0, but since we don't use it anyway we might as well just remove it completely